### PR TITLE
Sitemap fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "robotparser"
 readme = "README.md"
 repository = "https://github.com/messense/robotparser-rs"
-version = "0.10.2"
+version = "0.10.3"
 
 [dependencies]
 url = "1"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add it to your ``Cargo.toml``:
 
 ```toml
 [dependencies]
-robotparser = "0.10"
+robotparser = "^0.10"
 ```
 
 Add ``extern crate robotparser`` to your crate root and your're good to go!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,14 +461,14 @@ impl<'a> RobotFileParser<'a> {
     /// Returns the sitemaps for this user agent as a `Vec<Url>`.
     pub fn get_sitemaps<T: AsRef<str>>(&self, useragent: T) -> Vec<Url> {
         let useragent = useragent.as_ref();
-        let ret = Vec::new();
+        let mut ret = Vec::new();
         if self.last_checked.get() == 0 {
             return ret;
         }
         let entries = self.entries.borrow();
         for entry in &*entries {
             if entry.applies_to(useragent) {
-                ret.append( entry.get_sitemaps() );
+                ret.append( &mut entry.get_sitemaps( ).clone( ) );
             }
         }
         return ret;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,16 +461,17 @@ impl<'a> RobotFileParser<'a> {
     /// Returns the sitemaps for this user agent as a `Vec<Url>`.
     pub fn get_sitemaps<T: AsRef<str>>(&self, useragent: T) -> Vec<Url> {
         let useragent = useragent.as_ref();
+        let ret = Vec::new();
         if self.last_checked.get() == 0 {
-            return Vec::new();
+            return ret;
         }
         let entries = self.entries.borrow();
         for entry in &*entries {
             if entry.applies_to(useragent) {
-                return entry.get_sitemaps();
+                ret.append( entry.get_sitemaps() );
             }
         }
-        vec![]
+        return ret;
     }
 
     /// Returns the request rate for this user agent as a `RequestRate`, or None if not request rate is defined


### PR DESCRIPTION
Previously sitemaps would be returned only for the first entry matching the supplied user agent string. In most cases this doesn't matter, sitemaps are placed at the top of the robots.txt document, In others this means that `get_sitemaps()` returns an empty vector even when sitemap entries exist since they are placed below the `User-Agent:*` section.