### PR TITLE
Add support coverage via codecov + tarpaulin

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -120,13 +120,13 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:
-          path: ~/.cargo/registry
+          path: $HOME/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
         uses: actions/cache@v1
         with:
-          path: ~/.cargo/git
+          path: $HOME/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo build

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -45,6 +45,27 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-targets --all-features -- -D clippy::all
 
+  coverage:
+    name: Tarpaulin [Coverage]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v1
+        with:
+          name: code-coverage-report
+          path: cobertura.xml
+
   # Run a security audit on dependencies
   cargo_audit:
     name: Cargo Audit [Security]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GitHub Actions](https://github.com/messense/robotparser-rs/workflows/CI/badge.svg)](https://github.com/messense/robotparser-rs/actions?query=workflow%3ACI)
 [![Coverage Status](https://coveralls.io/repos/messense/robotparser-rs/badge.svg)](https://coveralls.io/r/messense/robotparser-rs)
+[![codecov](https://codecov.io/gh/messense/robotparser-rs/branch/master/graph/badge.svg)](https://codecov.io/gh/messense/robotparser-rs)
 [![Crates.io](https://img.shields.io/crates/v/robotparser.svg)](https://crates.io/crates/robotparser)
 [![Dependency status](https://deps.rs/repo/github/messense/robotparser-rs/status.svg)](https://deps.rs/repo/github/messense/robotparser-rs)
 


### PR DESCRIPTION
- workflows: add support coverage (Fixed #27)
- workflows: use HOME instead of '~' for fix macos cache build
