### PR TITLE
Crate is dependent on old reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ url = "2"
 percent-encoding = "2.1"
 
 [dependencies.reqwest]
-version = "0.11.0"
+version = "0.12"
 optional = true
 features = ["blocking"]
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -15,5 +15,7 @@ mod fetched_robots_txt;
 pub use self::robots_txt::RobotsTxt;
 mod path;
 pub(crate) use self::path::Path;
+#[cfg(feature = "reqwest")]
 mod errors;
+#[cfg(feature = "reqwest")]
 pub use self::errors::{Error, ErrorKind};

--- a/src/model/errors.rs
+++ b/src/model/errors.rs
@@ -8,6 +8,7 @@ pub struct Error {
 #[derive(Debug)]
 pub enum ErrorKind {
     Url(url::ParseError),
+    #[cfg(feature = "reqwest")]
     Http(reqwest::Error),
 }
 

--- a/src/model/errors.rs
+++ b/src/model/errors.rs
@@ -8,7 +8,6 @@ pub struct Error {
 #[derive(Debug)]
 pub enum ErrorKind {
     Url(url::ParseError),
-    #[cfg(feature = "reqwest")]
     Http(reqwest::Error),
 }
 

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -249,7 +249,7 @@ fn test_robots_txt_14() {
     robot_test_simple(doc, good, bad);
 }
 
-#[cfg(feature = "http")]
+#[cfg(feature = "reqwest")]
 #[test]
 fn test_robots_txt_read() {
     use reqwest::{Client, Request};


### PR DESCRIPTION
reqwest is being used in errors regardless of the feature gate, which makes it not compile without default features.

also updates reqwest from 0.11 to 0.12